### PR TITLE
Don't mark heap memory as executable

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: hsakmt-rocm-dev
-Architecture: amd64
+Architecture: $arch
 Maintainer: Advanced Micro Devices Inc.
 Depends:libpci3
 Priority: optional

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ PACKAGE_MINOR_VER = 0
 PACKAGE_PATCH_VER ?= 0
 PACKAGE_VER = $(PACKAGE_MAJOR_VER).$(PACKAGE_MINOR_VER).$(PACKAGE_PATCH_VER)
 export PACKAGE_VER
+DEB_BUILD_ARCH = $(shell dpkg --print-architecture | sed 's/ \*$i//g')
 
 # Compiler options
 CFLAGS += -fPIC # Position-independent code required to build shared library
@@ -96,9 +97,10 @@ package-common: lnx64a
 
 deb: package-common
 	@mkdir -p $(PACKAGE_DIR)/DEBIAN
-	@sed 's/\$$version/$(PACKAGE_VER)/g' $(DEBIAN_DIR)/control > $(PACKAGE_DIR)/DEBIAN/control
+	@sed 's/\$$version/$(PACKAGE_VER)/g;s/\$$arch/$(DEB_BUILD_ARCH)/g' $(DEBIAN_DIR)/control > $(PACKAGE_DIR)/DEBIAN/control
+
 	@fakeroot dpkg-deb --build $(PACKAGE_DIR) \
-		$(BUILDDIR)/hsakmt-dev-$(PACKAGE_VER)-amd64.deb
+		$(BUILDDIR)/hsakmt-dev-$(PACKAGE_VER)-${DEB_BUILD_ARCH}.deb
 
 rpm: package-common
 	@rpmbuild --define '_topdir $(BUILD_ROOT)/rpm' -ba $(THUNK_ROOT)/RPM/libhsakmt.spec

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -2512,6 +2512,7 @@ HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 	uint64_t offset;
 	int r;
 	HSAKMT_STATUS status = HSAKMT_STATUS_ERROR;
+	static const uint64_t IMAGE_ALIGN = 64*1024;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -2552,7 +2553,8 @@ HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 	if (!aperture_is_valid(aperture->base, aperture->limit))
 		goto error_free_metadata;
 	pthread_mutex_lock(&aperture->fmm_mutex);
-	mem = aperture_allocate_area(aperture, infoArgs.size, offset);
+	mem = aperture_allocate_area_aligned(aperture, infoArgs.size, offset,
+					     MAX(aperture->align, IMAGE_ALIGN));
 	pthread_mutex_unlock(&aperture->fmm_mutex);
 	if (!mem)
 		goto error_free_metadata;

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -2521,7 +2521,7 @@ HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 	uint64_t offset;
 	int r;
 	HSAKMT_STATUS status = HSAKMT_STATUS_ERROR;
-	static const uint64_t IMAGE_ALIGN = 64*1024;
+	static const uint64_t IMAGE_ALIGN = 256*1024;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -1093,25 +1093,21 @@ void *fmm_allocate_doorbell(uint32_t gpu_id, uint64_t MemorySizeInBytes,
 static void *fmm_allocate_host_cpu(uint64_t MemorySizeInBytes,
 				HsaMemFlags flags)
 {
-	int err;
-	HSAuint64 page_size;
 	void *mem = NULL;
 	vm_object_t *vm_obj;
+	int mmap_prot = PROT_READ | PROT_WRITE;
 
-	page_size = PageSizeFromFlags(flags.ui32.PageSize);
-	err = posix_memalign(&mem, page_size, MemorySizeInBytes);
-	if (err != 0)
+	if (flags.ui32.ExecuteAccess)
+		mmap_prot |= PROT_EXEC;
+
+	/* mmap will return a pointer with alignment equal to
+	 * sysconf(_SC_PAGESIZE).
+	 */
+	mem = mmap(NULL, MemorySizeInBytes, mmap_prot,
+			MAP_ANONYMOUS | MAP_PRIVATE, -1 , 0);
+
+	if (mem == MAP_FAILED)
 		return NULL;
-
-	if (flags.ui32.ExecuteAccess) {
-		err = mprotect(mem, MemorySizeInBytes,
-				PROT_READ | PROT_WRITE | PROT_EXEC);
-
-		if (err != 0) {
-			free(mem);
-			return NULL;
-		}
-	}
 
 	pthread_mutex_lock(&cpuvm_aperture.fmm_mutex);
 	vm_obj = aperture_allocate_object(&cpuvm_aperture, mem, 0,
@@ -1383,14 +1379,18 @@ void fmm_release(void *address)
 	 * refers to the system memory
 	 */
 	if (!found) {
+		uint64_t size = 0;
 		/* Release the vm object in CPUVM */
 		pthread_mutex_lock(&cpuvm_aperture.fmm_mutex);
 		object = vm_find_object_by_address(&cpuvm_aperture, address, 0);
-		if (object)
+		if (object) {
+			size = object->size;
 			vm_remove_object(&cpuvm_aperture, object);
+		}
 		pthread_mutex_unlock(&cpuvm_aperture.fmm_mutex);
 		/* Free the memory from the system */
-		free(address);
+		if (size)
+			munmap(address, size);
 	}
 }
 

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -539,10 +539,19 @@ static void *aperture_allocate_area_aligned(manageable_aperture_t *app,
 	vm_area_t *cur, *next;
 	void *start;
 
-	MemorySizeInBytes = vm_align_area_size(app, MemorySizeInBytes);
-
 	if (align < app->align)
 		align = app->align;
+
+	/* Huge-page and Big-K TLB optimizations require proper alignment */
+	if (MemorySizeInBytes >= GPU_HUGE_PAGE_SIZE) {
+		if (align < GPU_HUGE_PAGE_SIZE)
+			align = GPU_HUGE_PAGE_SIZE;
+	} else if (MemorySizeInBytes >= GPU_BIGK_PAGE_SIZE) {
+		if (align < GPU_BIGK_PAGE_SIZE)
+			align = GPU_BIGK_PAGE_SIZE;
+	}
+
+	MemorySizeInBytes = vm_align_area_size(app, MemorySizeInBytes);
 
 	/* Find a big enough "hole" in the address space */
 	cur = NULL;

--- a/src/libhsakmt.h
+++ b/src/libhsakmt.h
@@ -55,6 +55,12 @@ extern int PAGE_SHIFT;
 /* VI HW bug requires this virtual address alignment */
 #define TONGA_PAGE_SIZE 0x8000
 
+/* 64KB BigK fragment size for TLB efficiency */
+#define GPU_BIGK_PAGE_SIZE (1 << 16)
+
+/* 2MB huge page size for 4-level page tables on Vega10 and later GPUs */
+#define GPU_HUGE_PAGE_SIZE (2 << 20)
+
 #define CHECK_PAGE_MULTIPLE(x) \
 	do { if ((uint64_t)PORT_VPTR_TO_UINT64(x) % PAGE_SIZE) return HSAKMT_STATUS_INVALID_PARAMETER; } while(0)
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -330,11 +330,7 @@ static bool update_ctx_save_restore_size(uint32_t nodeid, struct queue *q)
 		ctl_stack_size = cu_num * WAVES_PER_CU_VI * 8 + 8;
 		wg_data_size = cu_num * WG_CONTEXT_DATA_SIZE_PER_CU_VI;
 		q->ctl_stack_size = PAGE_ALIGN_UP(ctl_stack_size);
-		q->ctx_save_restore_size = PAGE_ALIGN_UP(wg_data_size);
-
-		if (q->dev_info->asic_family < CHIP_VEGA10)
-			/* GFX8 chips store ctl-stack with WG data */
-			q->ctx_save_restore_size += q->ctl_stack_size;
+		q->ctx_save_restore_size = q->ctl_stack_size + PAGE_ALIGN_UP(wg_data_size);
 
 		return true;
 	}

--- a/src/queues.c
+++ b/src/queues.c
@@ -296,21 +296,20 @@ static HSAKMT_STATUS map_doorbell(HSAuint32 NodeId, HSAuint32 gpu_id,
 	return status;
 }
 
-static void *allocate_exec_aligned_memory_cpu(uint32_t size, uint32_t align)
+static void *allocate_exec_aligned_memory_cpu(uint32_t size)
 {
 	void *ptr;
-	int retval;
 
-	retval = posix_memalign(&ptr, align, size);
-	if (retval != 0)
-		return NULL;
+	/* mmap will return a pointer with alignment equal to
+	 * sysconf(_SC_PAGESIZE).
+	 *
+	 * MAP_ANONYMOUS initializes the memory to zero.
+	 */
+	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC,
+				MAP_ANONYMOUS | MAP_PRIVATE, -1 , 0);
 
-	retval = mprotect(ptr, size, PROT_READ | PROT_WRITE | PROT_EXEC);
-	if (retval != 0) {
-		free(ptr);
+	if (ptr == MAP_FAILED)
 		return NULL;
-	}
-	memset(ptr, 0, size);
 	return ptr;
 }
 
@@ -382,15 +381,17 @@ void free_exec_aligned_memory_gpu(void *addr, uint32_t size, uint32_t align)
 		hsaKmtFreeMemory(addr, size);
 }
 
+/*
+ * Allocates memory aligned to sysconf(_SC_PAGESIZE)
+ */
 static void *allocate_exec_aligned_memory(uint32_t size,
-					  uint32_t align,
 					  enum asic_family_type type,
 					  uint32_t NodeId)
 {
 	if (IS_DGPU(type))
-		return allocate_exec_aligned_memory_gpu(size, align, NodeId,
+		return allocate_exec_aligned_memory_gpu(size, PAGE_SIZE, NodeId,
 							false);
-	return allocate_exec_aligned_memory_cpu(size, align);
+	return allocate_exec_aligned_memory_cpu(size);
 }
 
 static void free_exec_aligned_memory(void *addr, uint32_t size, uint32_t align,
@@ -399,7 +400,7 @@ static void free_exec_aligned_memory(void *addr, uint32_t size, uint32_t align,
 	if (IS_DGPU(type))
 		free_exec_aligned_memory_gpu(addr, size, align);
 	else
-		free(addr);
+		munmap(addr, size);
 }
 
 static void free_queue(struct queue *q)
@@ -425,7 +426,6 @@ static int handle_concrete_asic(struct queue *q,
 		if (dev_info->eop_buffer_size > 0) {
 			q->eop_buffer =
 					allocate_exec_aligned_memory(q->dev_info->eop_buffer_size,
-					PAGE_SIZE,
 					dev_info->asic_family,
 					NodeId);
 			if (!q->eop_buffer)
@@ -440,7 +440,6 @@ static int handle_concrete_asic(struct queue *q,
 			args->ctl_stack_size = q->ctl_stack_size;
 			q->ctx_save_restore =
 				allocate_exec_aligned_memory(q->ctx_save_restore_size,
-							     PAGE_SIZE,
 							     dev_info->asic_family,
 							     NodeId);
 			if (!q->ctx_save_restore)
@@ -490,7 +489,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCreateQueue(HSAuint32 NodeId,
 	dev_info = get_device_info_by_dev_id(dev_id);
 
 	struct queue *q = allocate_exec_aligned_memory(sizeof(*q),
-			PAGE_SIZE, dev_info->asic_family,
+			dev_info->asic_family,
 			NodeId);
 	if (!q)
 		return HSAKMT_STATUS_NO_MEMORY;


### PR DESCRIPTION
Marking heap memory as executable using mprotect() is not allowed
by SELinux.  mprotect() calls that try to do this will fail on systems
with SELinux enabled.  This is also a security risk, so it should be
fixed even on systems that allow this.

Any memory we want to mark as executable must be allocated using mmap().
See https://www.akkadia.org/drepper/selinux-mem.html

The two places where we try to mark heap memory as executable both use
posix_memalign() to allocate the heap memory.  In both cases, the alignment
value passed into this function is always equal to PAGE_SIZE, which
means that they are safe to replace with mmap(), which guarantees alignment
to PAGE_SIZE.  In this case PAGE_SIZE has been set to sysconf(_SC_PAGESIZE);

This has been very minimally tested with the 4.14-rc4 kernel.  This is not my area of expertise, so I would appreciate a review and feedback.