### PR TITLE
Make it build with gcc>=6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set ( BUILD_VERSION_STRING "${BUILD_VERSION_MAJOR}.${BUILD_VERSION_MINOR}.${BUIL
 set ( CMAKE_VERBOSE_MAKEFILE on )
 
 ## Compiler flags
-set ( CMAKE_C_FLAGS "-fPIC -W -Wall -Wextra -Werror -Wno-unused-parameter -Wformat-security -Wswitch-default -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wunreachable-code -std=gnu99 -fvisibility=hidden -O2" )
+set ( CMAKE_C_FLAGS "-fPIC -W -Wall -Wextra -Werror -Wno-unused-parameter -Wformat-security -Wswitch-default -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wunreachable-code -std=gnu99 -fvisibility=hidden -O2" )
 
 set ( HSAKMT_LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/src/libhsakmt.ver" )
 

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: hsakmt-rocm-dev
-Architecture: amd64
+Architecture: $arch
 Maintainer: Advanced Micro Devices Inc.
 Depends:libpci3
 Priority: optional

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ PACKAGE_MINOR_VER = 0
 PACKAGE_PATCH_VER ?= 0
 PACKAGE_VER = $(PACKAGE_MAJOR_VER).$(PACKAGE_MINOR_VER).$(PACKAGE_PATCH_VER)
 export PACKAGE_VER
+DEB_BUILD_ARCH = $(shell dpkg --print-architecture | sed 's/ \*$i//g')
 
 # Compiler options
 CFLAGS += -fPIC # Position-independent code required to build shared library
@@ -96,9 +97,10 @@ package-common: lnx64a
 
 deb: package-common
 	@mkdir -p $(PACKAGE_DIR)/DEBIAN
-	@sed 's/\$$version/$(PACKAGE_VER)/g' $(DEBIAN_DIR)/control > $(PACKAGE_DIR)/DEBIAN/control
+	@sed 's/\$$version/$(PACKAGE_VER)/g;s/\$$arch/$(DEB_BUILD_ARCH)/g' $(DEBIAN_DIR)/control > $(PACKAGE_DIR)/DEBIAN/control
+
 	@fakeroot dpkg-deb --build $(PACKAGE_DIR) \
-		$(BUILDDIR)/hsakmt-dev-$(PACKAGE_VER)-amd64.deb
+		$(BUILDDIR)/hsakmt-dev-$(PACKAGE_VER)-${DEB_BUILD_ARCH}.deb
 
 rpm: package-common
 	@rpmbuild --define '_topdir $(BUILD_ROOT)/rpm' -ba $(THUNK_ROOT)/RPM/libhsakmt.spec

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -2512,6 +2512,7 @@ HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 	uint64_t offset;
 	int r;
 	HSAKMT_STATUS status = HSAKMT_STATUS_ERROR;
+	static const uint64_t IMAGE_ALIGN = 64*1024;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -2552,7 +2553,8 @@ HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 	if (!aperture_is_valid(aperture->base, aperture->limit))
 		goto error_free_metadata;
 	pthread_mutex_lock(&aperture->fmm_mutex);
-	mem = aperture_allocate_area(aperture, infoArgs.size, offset);
+	mem = aperture_allocate_area_aligned(aperture, infoArgs.size, offset,
+					     MAX(aperture->align, IMAGE_ALIGN));
 	pthread_mutex_unlock(&aperture->fmm_mutex);
 	if (!mem)
 		goto error_free_metadata;

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -2521,7 +2521,7 @@ HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 	uint64_t offset;
 	int r;
 	HSAKMT_STATUS status = HSAKMT_STATUS_ERROR;
-	static const uint64_t IMAGE_ALIGN = 64*1024;
+	static const uint64_t IMAGE_ALIGN = 256*1024;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -539,10 +539,19 @@ static void *aperture_allocate_area_aligned(manageable_aperture_t *app,
 	vm_area_t *cur, *next;
 	void *start;
 
-	MemorySizeInBytes = vm_align_area_size(app, MemorySizeInBytes);
-
 	if (align < app->align)
 		align = app->align;
+
+	/* Huge-page and Big-K TLB optimizations require proper alignment */
+	if (MemorySizeInBytes >= GPU_HUGE_PAGE_SIZE) {
+		if (align < GPU_HUGE_PAGE_SIZE)
+			align = GPU_HUGE_PAGE_SIZE;
+	} else if (MemorySizeInBytes >= GPU_BIGK_PAGE_SIZE) {
+		if (align < GPU_BIGK_PAGE_SIZE)
+			align = GPU_BIGK_PAGE_SIZE;
+	}
+
+	MemorySizeInBytes = vm_align_area_size(app, MemorySizeInBytes);
 
 	/* Find a big enough "hole" in the address space */
 	cur = NULL;

--- a/src/libhsakmt.h
+++ b/src/libhsakmt.h
@@ -55,6 +55,12 @@ extern int PAGE_SHIFT;
 /* VI HW bug requires this virtual address alignment */
 #define TONGA_PAGE_SIZE 0x8000
 
+/* 64KB BigK fragment size for TLB efficiency */
+#define GPU_BIGK_PAGE_SIZE (1 << 16)
+
+/* 2MB huge page size for 4-level page tables on Vega10 and later GPUs */
+#define GPU_HUGE_PAGE_SIZE (2 << 20)
+
 #define CHECK_PAGE_MULTIPLE(x) \
 	do { if ((uint64_t)PORT_VPTR_TO_UINT64(x) % PAGE_SIZE) return HSAKMT_STATUS_INVALID_PARAMETER; } while(0)
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -330,11 +330,7 @@ static bool update_ctx_save_restore_size(uint32_t nodeid, struct queue *q)
 		ctl_stack_size = cu_num * WAVES_PER_CU_VI * 8 + 8;
 		wg_data_size = cu_num * WG_CONTEXT_DATA_SIZE_PER_CU_VI;
 		q->ctl_stack_size = PAGE_ALIGN_UP(ctl_stack_size);
-		q->ctx_save_restore_size = PAGE_ALIGN_UP(wg_data_size);
-
-		if (q->dev_info->asic_family < CHIP_VEGA10)
-			/* GFX8 chips store ctl-stack with WG data */
-			q->ctx_save_restore_size += q->ctl_stack_size;
+		q->ctx_save_restore_size = q->ctl_stack_size + PAGE_ALIGN_UP(wg_data_size);
 
 		return true;
 	}


### PR DESCRIPTION
GCC>=6 is more aggressive about -Wlogical-op, and some if statements
are using the form `if (thing && thing != GOOD)`, where
`GOOD == 0`.

The problem with this warning is that it can create false
positives, as it has done in ROCT-Thunk-Interface. Hence why I
chose to disable the warning rather than alter the code. See the
discussion here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69602