### PR TITLE
Install libhsakmt.pc to the standard location

### DIFF
--- a/hsakmt-dev.txt
+++ b/hsakmt-dev.txt
@@ -43,7 +43,7 @@ set ( BUILD_VERSION_PATCH @BUILD_VERSION_PATCH@ )
 set ( CMAKE_VERBOSE_MAKEFILE on )
 
 ## Set the install targets
-install ( FILES libhsakmt.pc DESTINATION libhsakmt )
+install ( FILES libhsakmt.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig )
 install ( DIRECTORY ${SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HSAKMT_COMPONENT} )
 
 


### PR DESCRIPTION
pkgconfig files should be installed to /usr/share/pkgconfig/, not /usr/libhsakmt/