### PR TITLE
Use CMAKE_INSTALL_PREFIX in pkgconfig

### DIFF
--- a/libhsakmt.pc.in
+++ b/libhsakmt.pc.in
@@ -1,4 +1,4 @@
-prefix=@CPACK_PACKAGING_INSTALL_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@


### PR DESCRIPTION
The location where files are installed is the value to use; the CPACK packaging directory isn't important as the pkgconfig file is used on the system after the package is installed.