### PR TITLE
hsakmt-dev should not install linux kernel headers

### DIFF
--- a/hsakmt-dev.txt
+++ b/hsakmt-dev.txt
@@ -44,7 +44,7 @@ set ( CMAKE_VERBOSE_MAKEFILE on )
 
 ## Set the install targets
 install ( FILES libhsakmt.pc DESTINATION libhsakmt )
-install ( DIRECTORY ${SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HSAKMT_COMPONENT} )
+install ( DIRECTORY ${SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${HSAKMT_COMPONENT} PATTERN "linux" EXCLUDE )
 
 
 ## Set the default generator types for the devel package.

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -1469,6 +1469,12 @@ static int bind_mem_to_numa(uint32_t node_id, void *mem,
 
 	num_node = numa_num_task_nodes();
 
+	/* Ignore binding requests to invalid nodes IDs */
+	if (node_id >= (unsigned)num_node) {
+		pr_warn("node_id %d >= num_node %d\n", node_id, num_node);
+		return 0;
+	}
+
 	if (num_node > 1) {
 		node_mask = numa_bitmask_alloc(num_node);
 		if (!node_mask)


### PR DESCRIPTION
hsakmt-dev should not install include/linux/* (currently just kfd_ioctl.h) as those are linux kernel headers provided by the linux kernel header packages (`linux-headers-*` on Debian/Ubuntu or `kernel-headers-*` on Red Hat / Fedora)