### PR TITLE
check ret and errno

### DIFF
--- a/src/libhsakmt.c
+++ b/src/libhsakmt.c
@@ -13,7 +13,7 @@ int kmtIoctl(int fd, unsigned long request, void *arg)
 		ret = ioctl(fd, request, arg);
 	} while (ret == -1 && (errno == EINTR || errno == EAGAIN));
 
-	if (errno == EBADF) {
+	if (ret == -1 && errno == EBADF) {
 		/* In case pthread_atfork didn't catch it, this will
 		 * make any subsequent hsaKmt calls fail in CHECK_KFD_OPEN.
 		 */


### PR DESCRIPTION
Check `ret` along with `errno` to ensure that `errno` is related to fail.