### PR TITLE
libhsakmt: correct the maxnode argument in function mbind

### DIFF
--- a/src/fmm.c
+++ b/src/fmm.c
@@ -1498,7 +1498,7 @@ static int bind_mem_to_numa(uint32_t node_id, void *mem,
 
 	numa_bitmask_setbit(node_mask, node_id);
 	mode |= flags.ui32.NoSubstitute ? MPOL_BIND : MPOL_PREFERRED;
-	r = mbind(mem, SizeInBytes, mode, node_mask->maskp, num_node + 1, 0);
+	r = mbind(mem, SizeInBytes, mode, node_mask->maskp, num_node, 0);
 	numa_bitmask_free(node_mask);
 
 	if (r) {

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -714,10 +714,10 @@ static void *mmap_aperture_allocate_aligned(manageable_aperture_t *aper,
 		return NULL;
 	}
 
-	/* Align big buffers to the next power-of-2 up to huge page
-	 * size for flexible fragment size TLB optimizations
+	/* Align big buffers to the next power-of-2 up to 1GB
+	 * size for memory allocation optimization
 	 */
-	while (align < GPU_HUGE_PAGE_SIZE && size >= (align << 1))
+	while (align < GPU_GIANT_PAGE_SIZE && size >= (align << 1))
 		align <<= 1;
 
 	/* Add padding to guarantee proper alignment and leave guard

--- a/src/libhsakmt.h
+++ b/src/libhsakmt.h
@@ -72,6 +72,7 @@ extern int PAGE_SHIFT;
 
 /* 2MB huge page size for 4-level page tables on Vega10 and later GPUs */
 #define GPU_HUGE_PAGE_SIZE (2 << 20)
+#define GPU_GIANT_PAGE_SIZE (1 << 30)
 
 #define CHECK_PAGE_MULTIPLE(x) \
 	do { if ((uint64_t)PORT_VPTR_TO_UINT64(x) % PAGE_SIZE) return HSAKMT_STATUS_INVALID_PARAMETER; } while(0)

--- a/src/topology.c
+++ b/src/topology.c
@@ -1476,7 +1476,8 @@ static HSAKMT_STATUS topology_sysfs_get_iolink_props(uint32_t node_id,
 
 	read_size = fread(read_buf, 1, PAGE_SIZE, fd);
 	if (read_size <= 0) {
-		ret = HSAKMT_STATUS_ERROR;
+		ret = (errno == EPERM) ? HSAKMT_STATUS_NOT_SUPPORTED :
+					 HSAKMT_STATUS_ERROR;
 		goto err2;
 	}
 

--- a/tests/kfdtest/src/KFDLocalMemoryTest.cpp
+++ b/tests/kfdtest/src/KFDLocalMemoryTest.cpp
@@ -516,6 +516,11 @@ TEST_F(KFDLocalMemoryTest, MapVramToGPUNodesTest) {
         }
     }
 
+    if (!m_NodeInfo.IsPeerAccessibleByNode(dst_node, src_node)) {
+        LOG() << "Skipping test: GPUs are not peer-accessible" << std::endl;
+        return;
+    }
+
     LOG() << "Testing from GPU " << src_node << " to GPU " << dst_node << std::endl;
 
     void *shared_addr;


### PR DESCRIPTION
The maxnode argument is the maximum node number in the bit mask plus
one.

Signed-off-by: Guo Lei <raykwok1150@163.com>