### PR TITLE
Skip getting PAGE_SIZE when defined as macro

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -32,5 +32,7 @@ unsigned long kfd_open_count;
 unsigned long system_properties_count;
 pthread_mutex_t hsakmt_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool is_dgpu;
+#if !defined(PAGE_SIZE)
 int PAGE_SIZE;
+#endif
 int PAGE_SHIFT;

--- a/src/libhsakmt.h
+++ b/src/libhsakmt.h
@@ -56,7 +56,9 @@ extern HsaVersionInfo kfd_version_info;
 	do { if ((minor) > kfd_version_info.KernelInterfaceMinorVersion)\
 		return HSAKMT_STATUS_NOT_SUPPORTED; } while (0)
 
+#if !defined(PAGE_SIZE)
 extern int PAGE_SIZE;
+#endif
 extern int PAGE_SHIFT;
 
 /* VI HW bug requires this virtual address alignment */

--- a/src/libhsakmt.h
+++ b/src/libhsakmt.h
@@ -67,7 +67,6 @@ extern int PAGE_SHIFT;
 
 /* 2MB huge page size for 4-level page tables on Vega10 and later GPUs */
 #define GPU_HUGE_PAGE_SIZE (2 << 20)
-#define GPU_GIANT_PAGE_SIZE (1 << 30)
 
 #define CHECK_PAGE_MULTIPLE(x) \
 	do { if ((uint64_t)PORT_VPTR_TO_UINT64(x) % PAGE_SIZE) return HSAKMT_STATUS_INVALID_PARAMETER; } while(0)

--- a/src/openclose.c
+++ b/src/openclose.c
@@ -108,7 +108,9 @@ static void clear_after_fork(void)
 
 static inline void init_page_size(void)
 {
+#if !defined(PAGE_SIZE)
 	PAGE_SIZE = sysconf(_SC_PAGESIZE);
+#endif
 	PAGE_SHIFT = ffs(PAGE_SIZE) - 1;
 }
 


### PR DESCRIPTION
In some cases, e.g. [when using musl libc][1], PAGE_SIZE is defined as a macro  
To avoid compilation errors, only get PAGE_SIZE with sysconf when it's not defined

See #65 

[1]: https://elixir.bootlin.com/musl/v1.2.3/source/include/limits.h#L97