### PR TITLE
Add extended coherence memory flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ if(INCLUDE_PATH_COMPATIBILITY)
           set(ROCM_HEADER_WRAPPER_WERROR "$ENV{ROCM_HEADER_WRAPPER_WERROR}"
                   CACHE STRING "Header wrapper warnings as errors.")
       else()
-          set(ROCM_HEADER_WRAPPER_WERROR "ON" CACHE STRING "Header wrapper warnings as errors.")
+          set(ROCM_HEADER_WRAPPER_WERROR "OFF" CACHE STRING "Header wrapper warnings as errors.")
       endif()
   endif()
   if(ROCM_HEADER_WRAPPER_WERROR)

--- a/include/hsakmttypes.h
+++ b/include/hsakmttypes.h
@@ -564,7 +564,8 @@ typedef struct _HsaMemFlags
             unsigned int FixedAddress : 1; // Allocate memory at specified virtual address. Fail if address is not free.
             unsigned int NoNUMABind:    1; // Don't bind system memory to a specific NUMA node
             unsigned int Uncached:      1; // Caching flag for fine-grained memory on A+A HW platform
-            unsigned int Reserved    : 14;
+            unsigned int ExtendedCoherent: 1;  // system-scope coherence on atomic instructions
+            unsigned int Reserved    : 13;
 
         } ui32;
         HSAuint32 Value;
@@ -1334,6 +1335,7 @@ typedef enum _HSA_SVM_FLAGS {
 	HSA_SVM_FLAG_GPU_EXEC    = 0x00000010, // Allow execution on GPU
 	HSA_SVM_FLAG_GPU_READ_MOSTLY = 0x00000020, // GPUs mostly read, may allow similar optimizations as RO, but writes fault
 	HSA_SVM_FLAG_GPU_ALWAYS_MAPPED = 0x00000040, // Keep GPU memory mapping always valid as if XNACK is disable
+	HSA_SVM_FLAG_EXT_COHERENT = 0x00000080, //  Fine grained coherency between all devices using device-scope atomics
 } HSA_SVM_FLAGS;
 
 typedef enum _HSA_SVM_ATTR_TYPE {

--- a/include/linux/kfd_ioctl.h
+++ b/include/linux/kfd_ioctl.h
@@ -743,6 +743,7 @@ struct kfd_ioctl_acquire_vm_args {
 #define KFD_IOC_ALLOC_MEM_FLAGS_AQL_QUEUE_MEM	(1 << 27)
 #define KFD_IOC_ALLOC_MEM_FLAGS_COHERENT	(1 << 26)
 #define KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED	(1 << 25)
+#define KFD_IOC_ALLOC_MEM_FLAGS_EXT_COHERENT	(1 << 24)
 
 /* Allocate memory for later SVM (shared virtual memory) mapping.
  *
@@ -1091,6 +1092,8 @@ struct kfd_ioctl_cross_memory_copy_args {
 #define KFD_IOCTL_SVM_FLAG_GPU_READ_MOSTLY     0x00000020
 /* Keep GPU memory mapping always valid as if XNACK is disable */
 #define KFD_IOCTL_SVM_FLAG_GPU_ALWAYS_MAPPED   0x00000040
+/* Fine grained coherency between all devices using device-scope atomics */
+#define KFD_IOCTL_SVM_FLAG_EXT_COHERENT        0x00000080
 
 /**
  * kfd_ioctl_svm_op - SVM ioctl operations

--- a/src/events.c
+++ b/src/events.c
@@ -285,6 +285,8 @@ static HSAKMT_STATUS get_mem_info_svm_api(uint64_t address, uint32_t gpu_id)
 				pr_err("GPU exec allowed\n");
 			if (args->attrs[i].value & KFD_IOCTL_SVM_FLAG_GPU_ALWAYS_MAPPED)
 				 pr_err("GPU always mapped\n");
+			if (args->attrs[i].value & KFD_IOCTL_SVM_FLAG_EXT_COHERENT)
+				 pr_err("Extended-scope fine grained coherency between devices\n");
 			break;
 		default:
 			pr_debug("get invalid attr type 0x%x\n", args->attrs[i].type);

--- a/src/fmm.c
+++ b/src/fmm.c
@@ -960,6 +960,8 @@ static HsaMemFlags fmm_translate_ioc_to_hsa_flags(uint32_t ioc_flags)
 		mflags.ui32.ReadOnly = 1;
 	if (!(ioc_flags & KFD_IOC_ALLOC_MEM_FLAGS_COHERENT))
 		mflags.ui32.CoarseGrain = 1;
+	if (ioc_flags & KFD_IOC_ALLOC_MEM_FLAGS_EXT_COHERENT)
+		mflags.ui32.ExtendedCoherent = 1;
 	if (ioc_flags & KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC)
 		mflags.ui32.HostAccess = 1;
 	return mflags;
@@ -967,7 +969,8 @@ static HsaMemFlags fmm_translate_ioc_to_hsa_flags(uint32_t ioc_flags)
 
 static HSAKMT_STATUS fmm_register_mem_svm_api(void *address,
 					      uint64_t size,
-					      bool coarse_grain)
+					      bool coarse_grain,
+					      bool ext_coherent)
 {
 	struct kfd_ioctl_svm_args *args;
 	size_t s_attr;
@@ -978,15 +981,17 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(void *address,
 	if (!g_first_gpu_mem)
 		return HSAKMT_STATUS_ERROR;
 
-	s_attr = sizeof(struct kfd_ioctl_svm_attribute);
+	s_attr = 2 * sizeof(struct kfd_ioctl_svm_attribute);
 	args = alloca(sizeof(*args) + s_attr);
 	args->start_addr = aligned_addr;
 	args->size = aligned_size;
 	args->op = KFD_IOCTL_SVM_OP_SET_ATTR;
-	args->nattr = 1;
+	args->nattr = 2;
 	args->attrs[0].type = coarse_grain ?
 			      HSA_SVM_ATTR_CLR_FLAGS : HSA_SVM_ATTR_SET_FLAGS;
 	args->attrs[0].value = HSA_SVM_FLAG_COHERENT;
+	args->attrs[1].type = ext_coherent ? HSA_SVM_ATTR_CLR_FLAGS : HSA_SVM_ATTR_SET_FLAGS;
+	args->attrs[1].value = HSA_SVM_FLAG_EXT_COHERENT;
 	pr_debug("Registering to SVM %p size: %ld\n", (void*)aligned_addr,
 		 aligned_size);
 	/* Driver does one copy_from_user, with extra attrs size */
@@ -1316,6 +1321,9 @@ static uint32_t fmm_translate_hsa_to_ioc_flags(HsaMemFlags flags)
 			      KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED);
 	if (!flags.ui32.ReadOnly)
 		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+	if (flags.ui32.ExtendedCoherent)
+		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_EXT_COHERENT;
+
 	/* TODO: Since, ROCr interfaces doesn't allow caller to set page
 	 * permissions, mark all user allocations with exec permission.
 	 * Check for flags.ui32.ExecuteAccess once ROCr is ready.
@@ -1470,6 +1478,9 @@ void *fmm_allocate_device(uint32_t gpu_id, uint32_t node_id, void *address,
 	if (mflags.ui32.Uncached || svm.disable_cache)
 		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED;
 
+	if (mflags.ui32.ExtendedCoherent)
+		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_EXT_COHERENT;
+
 	mem = __fmm_allocate_device(gpu_id, address, size, aperture, &mmap_offset,
 				    ioc_flags, &vm_obj);
 
@@ -1526,7 +1537,7 @@ void *fmm_allocate_doorbell(uint32_t gpu_id, uint64_t MemorySizeInBytes,
 		mflags.Value = 0;
 		mflags.ui32.NonPaged = 1;
 		mflags.ui32.HostAccess = 1;
-		mflags.ui32.Reserved = 0xBe1;
+		mflags.ui32.Reserved = 0x3e1;
 
 		pthread_mutex_lock(&aperture->fmm_mutex);
 		vm_obj->mflags = mflags;
@@ -1675,6 +1686,9 @@ static void *fmm_allocate_host_gpu(uint32_t node_id, void *address,
 
 	if (!mflags.ui32.CoarseGrain || svm.disable_cache)
 		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_COHERENT;
+
+	if (!mflags.ui32.ExtendedCoherent || svm.disable_cache)
+		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_EXT_COHERENT;
 
 	if (mflags.ui32.Uncached || svm.disable_cache)
 		ioc_flags |= KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED;
@@ -3177,8 +3191,11 @@ bool fmm_get_handle(void *address, uint64_t *handle)
 	return found;
 }
 
-static HSAKMT_STATUS fmm_register_user_memory(void *addr, HSAuint64 size,
-				  vm_object_t **obj_ret, bool coarse_grain)
+static HSAKMT_STATUS fmm_register_user_memory(void *addr,
+						HSAuint64 size,
+						vm_object_t **obj_ret,
+						bool coarse_grain,
+						bool ext_coherent)
 {
 	manageable_aperture_t *aperture = svm.dgpu_aperture;
 	HSAuint32 page_offset = (HSAuint64)addr & (PAGE_SIZE-1);
@@ -3203,7 +3220,8 @@ static HSAKMT_STATUS fmm_register_user_memory(void *addr, HSAuint64 size,
 			 &aligned_addr, KFD_IOC_ALLOC_MEM_FLAGS_USERPTR |
 			 KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
 			 KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE |
-			 (coarse_grain ? 0 : KFD_IOC_ALLOC_MEM_FLAGS_COHERENT),
+			 (coarse_grain ? 0 : KFD_IOC_ALLOC_MEM_FLAGS_COHERENT) |
+			 (ext_coherent ? 0 : KFD_IOC_ALLOC_MEM_FLAGS_EXT_COHERENT),
 			 &obj);
 	if (!svm_addr)
 		return HSAKMT_STATUS_ERROR;
@@ -3240,13 +3258,17 @@ static HSAKMT_STATUS fmm_register_user_memory(void *addr, HSAuint64 size,
 HSAKMT_STATUS fmm_register_memory(void *address, uint64_t size_in_bytes,
 				  uint32_t *gpu_id_array,
 				  uint32_t gpu_id_array_size,
-				  bool coarse_grain)
+				  bool coarse_grain,
+				  bool ext_coherent)
 {
 	manageable_aperture_t *aperture = NULL;
 	vm_object_t *object = NULL;
 	HSAKMT_STATUS ret;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
+		return HSAKMT_STATUS_INVALID_PARAMETER;
+
+	if (coarse_grain && ext_coherent)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
 
 	object = vm_find_object(address, size_in_bytes, &aperture);
@@ -3257,9 +3279,17 @@ HSAKMT_STATUS fmm_register_memory(void *address, uint64_t size_in_bytes,
 
 		/* Register a new user ptr */
 		if (svm.is_svm_api_supported)
-			return fmm_register_mem_svm_api(address, size_in_bytes, coarse_grain);
+			return fmm_register_mem_svm_api(address,
+							size_in_bytes,
+							coarse_grain,
+							ext_coherent);
 
-		ret = fmm_register_user_memory(address, size_in_bytes, &object, coarse_grain);
+		ret = fmm_register_user_memory(address,
+					       size_in_bytes,
+					       &object,
+					       coarse_grain,
+					       ext_coherent);
+
 		if (ret != HSAKMT_STATUS_SUCCESS)
 			return ret;
 		if (gpu_id_array_size == 0)

--- a/src/fmm.h
+++ b/src/fmm.h
@@ -72,7 +72,8 @@ HSAKMT_STATUS fmm_get_aperture_base_and_limit(aperture_type_e aperture_type, HSA
 HSAKMT_STATUS fmm_register_memory(void *address, uint64_t size_in_bytes,
 								  uint32_t *gpu_id_array,
 								  uint32_t gpu_id_array_size,
-								  bool coarse_grain);
+								  bool coarse_grain,
+								  bool ext_coherent);
 HSAKMT_STATUS fmm_register_graphics_handle(HSAuint64 GraphicsResourceHandle,
 					   HsaGraphicsResourceInfo *GraphicsResourceInfo,
 					   uint32_t *gpu_id_array,


### PR DESCRIPTION
Add support for new flag for memory allocation that will provide system-scope coherent atomics

<Note: I will bring-in this change internal AMD repository. Posting patch here for reference only>