### PR TITLE
Update doorbell->size to support large default PAGE_SIZE kernels

### DIFF
--- a/src/queues.c
+++ b/src/queues.c
@@ -135,6 +135,10 @@ static void get_doorbell_map_info(uint32_t node_id,
 	doorbell->use_gpuvm = (is_dgpu && gfxv != GFX_VERSION_TONGA);
 	doorbell->size = DOORBELLS_PAGE_SIZE(DOORBELL_SIZE(gfxv));
 
+	if (doorbell->size < (uint32_t) PAGE_SIZE) {
+		doorbell->size = PAGE_SIZE;
+	}
+	
 	return;
 }
 


### PR DESCRIPTION
In some architectures, the default page size of the kernel can be configured (such as PPC, LoongArch). In ROCK-Kernel-Driver, PAGE_SIZE is processed to ensure that there will be no abnormal allocation.

However, this project does not deal with PAGE_SIZE changes. When PAGE_SIZE exceeds 8K, an exception will occur.

This patch does not affect the architecture of the 4K default page size (such as AMD64) as much as possible. And when the page size exceeds 8K, keep it as consistent with the driver as possible.

The following is the general process of triggering an exception, and there will be no exception after repair.

```mermaid
sequenceDiagram
process ->> hsaKmtCreateQueue : 
hsaKmtCreateQueue ->> get_doorbell_map_info : only gen `4k` or `8k`
get_doorbell_map_info ->> hsaKmtCreateQueue : 
hsaKmtCreateQueue ->> map_doorbell_dgpu : 
map_doorbell_dgpu ->> k.kfd_ioctl_alloc_memory_of_gpu : 
k.kfd_ioctl_alloc_memory_of_gpu ->> k.kfd_doorbell_process_slice : check size
k.kfd_doorbell_process_slice ->> k.PAGE_SIZE : roundup BY PAGE_SIZE
k.kfd_doorbell_process_slice -->> map_doorbell_dgpu : if PAGE_SIZE > 8k, will EINVAL .
map_doorbell_dgpu -->> hsaKmtCreateQueue : FAILED
```

